### PR TITLE
Grafana on the EKS cluster

### DIFF
--- a/scripts/eks/grafana-variables.yaml
+++ b/scripts/eks/grafana-variables.yaml
@@ -1,0 +1,20 @@
+# https://github.com/grafana/helm-charts/blob/main/charts/grafana/README.md#configuration
+datasources:
+  datasources.yaml:
+    apiVersion: 1
+    datasources:
+    - name: InfluxDB
+      type: influxdb
+      access: proxy
+      url: http://influxdb.default.svc.cluster.local:8086
+      database: testground
+      uid: ds_influxdb
+      isDefault: true
+grafana.ini:
+  auth.anonymous:
+    enabled: true
+    org_role: Admin
+sidecar:
+  dashboards:
+    enabled: true
+

--- a/scripts/eks/grafana-variables.yaml
+++ b/scripts/eks/grafana-variables.yaml
@@ -17,4 +17,7 @@ grafana.ini:
 sidecar:
   dashboards:
     enabled: true
+    folderAnnotation: grafana_dashboard_folder
+    provider:
+      foldersFromFilesStructure: true
 

--- a/scripts/eks/monitoring.sh
+++ b/scripts/eks/monitoring.sh
@@ -9,14 +9,15 @@ create_configmap() {
   # The name of configmap must consist of lower case alphanumeric characters, '-' or '.'
   name="$1_$(basename -s ".json" "$2")"
   name=$(echo "$name" | tr "[:upper:]" "[:lower:]" | tr "_" "-")
-  kubectl create configmap "dashboard-$name" --from-file=$2
+  kubectl create configmap "dashboard-$name" --from-file="$2"
   kubectl label configmap "dashboard-$name" grafana_dashboard=1
+  kubectl annotate configmap "dashboard-$name" grafana_dashboard_folder="$1"
 }
 
 create_configmaps() {
-  find $project_root/$1/dashboards/ -name "*.json" -type f | while read -r fname
+  find "${project_root}/$1/dashboards/" -name "*.json" -type f | while read -r fname
   do
-    create_configmap $1 $fname
+    create_configmap "$1" "${fname}"
   done
 }
 
@@ -30,6 +31,14 @@ create_configmaps "eth_consensus"
 create_configmaps "scoring"
 
 # Install Grafana
+echo -e "Now obtaining the helm charts and installing Grafana. This might take a few minutes.\n"
 helm repo add grafana https://grafana.github.io/helm-charts
 helm repo update
-helm install gossipsub-grafana grafana/grafana -f $script_dir/grafana-variables.yaml
+helm install gossipsub-grafana grafana/grafana -f "${script_dir}/grafana-variables.yaml"
+
+echo -e "\n============================================================================================================="
+echo -e "You may run the following in order to obtain the grafana pod name:"
+echo -e 'export POD_NAME=$(kubectl get pods --namespace default -l "app.kubernetes.io/name=grafana,app.kubernetes.io/instance=gossipsub-grafana" -o jsonpath="{.items[0].metadata.name}")\n'
+echo -e "You may now run the following in order to port-forward and access the grafana dashboard from your laptop by opening 'localhost:3000' in your browser:"
+echo -e 'kubectl --namespace default port-forward $POD_NAME 3000'
+echo -e "============================================================================================================\n"

--- a/scripts/eks/monitoring.sh
+++ b/scripts/eks/monitoring.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# This script deploys Grafana resources to the EKS cluster.
+# Our custom dashboards and datasource settings are preset to the deployed grafana instance.
+
+set -Eeuo pipefail
+
+create_configmap() {
+  # The name of configmap must consist of lower case alphanumeric characters, '-' or '.'
+  name="$1_$(basename -s ".json" "$2")"
+  name=$(echo "$name" | tr "[:upper:]" "[:lower:]" | tr "_" "-")
+  kubectl create configmap "dashboard-$name" --from-file=$2
+  kubectl label configmap "dashboard-$name" grafana_dashboard=1
+}
+
+create_configmaps() {
+  find $project_root/$1/dashboards/ -name "*.json" -type f | while read -r fname
+  do
+    create_configmap $1 $fname
+  done
+}
+
+readonly script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+readonly project_root=$(cd "${script_dir}/../../" &>/dev/null && pwd -P)
+
+# Create configmaps for dashboards
+# https://github.com/grafana/helm-charts/blob/main/charts/grafana/README.md#sidecar-for-dashboards
+create_configmaps "censoring"
+create_configmaps "eth_consensus"
+create_configmaps "scoring"
+
+# Install Grafana
+helm repo add grafana https://grafana.github.io/helm-charts
+helm repo update
+helm install gossipsub-grafana grafana/grafana -f $script_dir/grafana-variables.yaml


### PR DESCRIPTION
Added a script to make it easy to create a Grafana instance in which our dashboards are preset, on the EKS cluster.

```bash
$ ./monitoring.sh

$ export POD_NAME=$(kubectl get pods --namespace default -l "app.kubernetes.io/name=grafana,app.kubernetes.io/instance=gossipsub-grafana" -o jsonpath="{.items[0].metadata.name}")

$ kubectl --namespace default port-forward $POD_NAME 3000
```


<img width="826" alt="image" src="https://user-images.githubusercontent.com/1885716/222877970-d6faf2bd-a26f-4aac-b7f4-7d51783ed2be.png">
